### PR TITLE
Fix timestamp bug

### DIFF
--- a/src/components/ChatWindow/ChatContainer/ChatHistory/PromptReply/index.jsx
+++ b/src/components/ChatWindow/ChatContainer/ChatHistory/PromptReply/index.jsx
@@ -6,7 +6,7 @@ import AnythingLLMIcon from "@/assets/anything-llm-icon.svg";
 import { formatDate } from "@/utils/date";
 
 const PromptReply = forwardRef(
-  ({ uuid, reply, pending, error, sources = [] }, ref) => {
+  ({ uuid, reply, pending, error, sources = [], sentAt }, ref) => {
     if (!reply && sources.length === 0 && !pending && !error) return null;
     if (error) console.error(`ANYTHING_LLM_CHAT_WIDGET_ERROR: ${error}`);
 
@@ -98,11 +98,13 @@ const PromptReply = forwardRef(
             </div>
           </div>
         </div>
-        <div
-          className={`allm-text-[10px] allm-text-gray-400 allm-ml-[54px] allm-mr-6 allm-mt-2 allm-text-left allm-font-sans`}
-        >
-          {formatDate(Date.now() / 1000)}
-        </div>
+        {sentAt && (
+          <div
+            className={`allm-text-[10px] allm-text-gray-400 allm-ml-[54px] allm-mr-6 allm-mt-2 allm-text-left allm-font-sans`}
+          >
+            {formatDate(sentAt)}
+          </div>
+        )}
       </div>
     );
   }

--- a/src/components/ChatWindow/ChatContainer/index.jsx
+++ b/src/components/ChatWindow/ChatContainer/index.jsx
@@ -3,7 +3,6 @@ import ChatHistory from "./ChatHistory";
 import PromptInput from "./PromptInput";
 import handleChat from "@/utils/chat";
 import ChatService from "@/models/chatService";
-import { formatDate } from "@/utils/date";
 export const SEND_TEXT_EVENT = "anythingllm-embed-send-prompt";
 
 export default function ChatContainer({

--- a/src/components/ChatWindow/ChatContainer/index.jsx
+++ b/src/components/ChatWindow/ChatContainer/index.jsx
@@ -3,6 +3,7 @@ import ChatHistory from "./ChatHistory";
 import PromptInput from "./PromptInput";
 import handleChat from "@/utils/chat";
 import ChatService from "@/models/chatService";
+import { formatDate } from "@/utils/date";
 export const SEND_TEXT_EVENT = "anythingllm-embed-send-prompt";
 
 export default function ChatContainer({
@@ -32,13 +33,14 @@ export default function ChatContainer({
 
     const prevChatHistory = [
       ...chatHistory,
-      { content: message, role: "user" },
+      { content: message, role: "user", sentAt: Math.floor(Date.now() / 1000) },
       {
         content: "",
         role: "assistant",
         pending: true,
         userMessage: message,
         animate: true,
+        sentAt: Math.floor(Date.now() / 1000),
       },
     ];
     setChatHistory(prevChatHistory);

--- a/src/utils/chat/index.js
+++ b/src/utils/chat/index.js
@@ -16,6 +16,10 @@ export default function handleChat(
     errorMsg = null,
   } = chatResult;
 
+  // Preserve the sentAt from the last message in the chat history
+  const lastMessage = _chatHistory[_chatHistory.length - 1];
+  const sentAt = lastMessage?.sentAt;
+
   if (type === "abort") {
     setLoadingResponse(false);
     setChatHistory([
@@ -30,6 +34,7 @@ export default function handleChat(
         errorMsg,
         animate: false,
         pending: false,
+        sentAt,
       },
     ]);
     _chatHistory.push({
@@ -42,6 +47,7 @@ export default function handleChat(
       errorMsg,
       animate: false,
       pending: false,
+      sentAt,
     });
   } else if (type === "textResponse") {
     setLoadingResponse(false);
@@ -57,6 +63,7 @@ export default function handleChat(
         errorMsg,
         animate: !close,
         pending: false,
+        sentAt,
       },
     ]);
     _chatHistory.push({
@@ -69,6 +76,7 @@ export default function handleChat(
       errorMsg,
       animate: !close,
       pending: false,
+      sentAt,
     });
   } else if (type === "textResponseChunk") {
     const chatIdx = _chatHistory.findIndex((chat) => chat.uuid === uuid);
@@ -83,6 +91,7 @@ export default function handleChat(
         closed: close,
         animate: !close,
         pending: false,
+        sentAt,
       };
       _chatHistory[chatIdx] = updatedHistory;
     } else {
@@ -96,6 +105,7 @@ export default function handleChat(
         closed: close,
         animate: !close,
         pending: false,
+        sentAt,
       });
     }
     setChatHistory([..._chatHistory]);

--- a/src/utils/date.js
+++ b/src/utils/date.js
@@ -1,9 +1,15 @@
 export function formatDate(sentAt) {
-  const date = new Date(sentAt * 1000);
-  const timeString = date.toLocaleTimeString([], {
-    hour: "numeric",
-    minute: "2-digit",
-    hour12: true,
-  });
-  return timeString;
+  if (!sentAt) return "";
+
+  try {
+    const date = new Date(sentAt * 1000);
+    const timeString = date.toLocaleTimeString([], {
+      hour: "numeric",
+      minute: "2-digit",
+      hour12: true,
+    });
+    return timeString;
+  } catch (e) {
+    return "";
+  }
 }


### PR DESCRIPTION
Fixed a bug where messages that were just sent in the embed widget were not using the correct `sentAt` time.

- Any messages that were sent and appended to the history array did not have a `sentAt` attribute causing the time to fallback on the current time which would rerender on key press of the chat input box
- Fixed by storing current time message was sent at and modified the chat util to preserve this time so that it stays accurate and does not fallback anymore on the current time