### PR TITLE
Add thoughts option to embed chat widget + UI improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,8 @@ REQUIRED data attributes:
 
 - `data-open-on-load` — Once loaded, open the chat as default. It can still be closed by the user. To enable set this attribute to `on`. All other values will be ignored.
 
+- `data-show-thoughts` — Allow users to see the AI's thought process in responses. If set to "false", users will only see the thinking state. Defaults to "true".
+
 - `data-support-email` — Shows a support email that the user can used to draft an email via the "three dot" menu in the top right. Option will not appear if it is not set.
 
 ### `<iframe>` tag HTML embed

--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ REQUIRED data attributes:
 
 - `data-open-on-load` — Once loaded, open the chat as default. It can still be closed by the user. To enable set this attribute to `on`. All other values will be ignored.
 
-- `data-show-thoughts` — Allow users to see the AI's thought process in responses. If set to "false", users will only see the thinking state. Defaults to "true".
+- `data-show-thoughts` — Allow users to see the AI's thought process, if applicable, in responses. If set to "false", users will only see a static "Thinking" indication without the explict thought content. If "true" the user will see the full thought content as well as the real response. Defaults to "false".
 
 - `data-support-email` — Shows a support email that the user can used to draft an email via the "three dot" menu in the top right. Option will not appear if it is not set.
 

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -41,7 +41,7 @@ export default function App() {
           style={{
             maxWidth: windowWidth,
             maxHeight: windowHeight,
-            height: "100%"
+            height: "100%",
           }}
           className={`allm-h-full allm-w-full allm-bg-white allm-fixed allm-bottom-0 allm-right-0 allm-mb-4 allm-md:mr-4 allm-rounded-2xl allm-border allm-border-gray-300 allm-shadow-[0_4px_14px_rgba(0,0,0,0.25)] allm-flex allm-flex-col ${positionClasses[position]}`}
           id="anything-llm-chat"

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -41,8 +41,9 @@ export default function App() {
           style={{
             maxWidth: windowWidth,
             maxHeight: windowHeight,
+            height: "100%"
           }}
-          className={`allm-h-full allm-w-full allm-bg-white allm-fixed allm-bottom-0 allm-right-0 allm-mb-4 allm-md:mr-4 allm-rounded-2xl allm-border allm-border-gray-300 allm-shadow-[0_4px_14px_rgba(0,0,0,0.25)] ${positionClasses[position]}`}
+          className={`allm-h-full allm-w-full allm-bg-white allm-fixed allm-bottom-0 allm-right-0 allm-mb-4 allm-md:mr-4 allm-rounded-2xl allm-border allm-border-gray-300 allm-shadow-[0_4px_14px_rgba(0,0,0,0.25)] allm-flex allm-flex-col ${positionClasses[position]}`}
           id="anything-llm-chat"
         >
           {isChatOpen && (

--- a/src/components/ChatWindow/ChatContainer/ChatHistory/HistoricalMessage/index.jsx
+++ b/src/components/ChatWindow/ChatContainer/ChatHistory/HistoricalMessage/index.jsx
@@ -28,7 +28,9 @@ const ThoughtBubble = ({ thought }) => {
       </div>
       {isExpanded && (
         <div className="allm-mt-2 allm-mb-3 allm-pl-0 allm-border-l-2 allm-border-gray-200">
-          <div className="allm-text-xs allm-text-gray-600 allm-font-mono allm-whitespace-pre-wrap">{thought.trim()}</div>
+          <div className="allm-text-xs allm-text-gray-600 allm-font-mono allm-whitespace-pre-wrap">
+            {thought.trim()}
+          </div>
         </div>
       )}
     </div>
@@ -55,18 +57,21 @@ const HistoricalMessage = forwardRef(
 
     // Extract content between think tags if they exist
     const thinkMatches = message?.match(/<think>([\s\S]*?)<\/think>/g) || [];
-    const thoughts = thinkMatches.map(match =>
-      match.replace(/<think>|<\/think>/g, '').trim()
+    const thoughts = thinkMatches.map((match) =>
+      match.replace(/<think>|<\/think>/g, "").trim()
     );
 
     // Get the response content without the think tags
-    const responseContent = message?.replace(/<think>[\s\S]*?<\/think>/g, "").trim();
+    const responseContent = message
+      ?.replace(/<think>[\s\S]*?<\/think>/g, "")
+      .trim();
 
     return (
       <div className="allm-py-[5px]">
         {role === "assistant" && (
           <div className="allm-text-[10px] allm-text-gray-400 allm-ml-[54px] allm-mr-6 allm-mb-2 allm-text-left allm-font-sans">
-            {embedderSettings.settings.assistantName || "Anything LLM Chat Assistant"}
+            {embedderSettings.settings.assistantName ||
+              "Anything LLM Chat Assistant"}
           </div>
         )}
         <div
@@ -119,7 +124,9 @@ const HistoricalMessage = forwardRef(
                   <span
                     className={`allm-whitespace-pre-line allm-flex allm-flex-col allm-gap-y-1 ${textSize} allm-leading-[20px]`}
                     dangerouslySetInnerHTML={{
-                      __html: DOMPurify.sanitize(renderMarkdown(responseContent || message)),
+                      __html: DOMPurify.sanitize(
+                        renderMarkdown(responseContent || message)
+                      ),
                     }}
                   />
                 </>

--- a/src/components/ChatWindow/ChatContainer/ChatHistory/HistoricalMessage/index.jsx
+++ b/src/components/ChatWindow/ChatContainer/ChatHistory/HistoricalMessage/index.jsx
@@ -1,5 +1,5 @@
-import React, { memo, forwardRef } from "react";
-import { Warning } from "@phosphor-icons/react";
+import React, { memo, forwardRef, useState } from "react";
+import { Warning, CaretDown } from "@phosphor-icons/react";
 import renderMarkdown from "@/utils/chat/markdown";
 import { embedderSettings } from "@/main";
 import { v4 } from "uuid";
@@ -8,6 +8,33 @@ import AnythingLLMIcon from "@/assets/anything-llm-icon.svg";
 import { formatDate } from "@/utils/date";
 
 const DOMPurify = createDOMPurify(window);
+
+const ThoughtBubble = ({ thought }) => {
+  const [isExpanded, setIsExpanded] = useState(false);
+  if (!thought || !embedderSettings.settings.showThoughts) return null;
+
+  return (
+    <div className="allm-mb-2">
+      <div
+        onClick={() => setIsExpanded(!isExpanded)}
+        className="allm-cursor-pointer allm-flex allm-items-center allm-gap-x-1.5 allm-text-gray-400 hover:allm-text-gray-500"
+      >
+        <CaretDown
+          size={14}
+          weight="bold"
+          className={`allm-transition-transform ${isExpanded ? "allm-rotate-180" : ""}`}
+        />
+        <span className="allm-text-xs allm-font-medium">View thoughts</span>
+      </div>
+      {isExpanded && (
+        <div className="allm-mt-2 allm-mb-3 allm-pl-0 allm-border-l-2 allm-border-gray-200">
+          <div className="allm-text-xs allm-text-gray-600 allm-font-mono allm-whitespace-pre-wrap">{thought.trim()}</div>
+        </div>
+      )}
+    </div>
+  );
+};
+
 const HistoricalMessage = forwardRef(
   (
     {
@@ -26,14 +53,20 @@ const HistoricalMessage = forwardRef(
       : "allm-text-sm";
     if (error) console.error(`ANYTHING_LLM_CHAT_WIDGET_ERROR: ${error}`);
 
+    // Extract content between think tags if they exist
+    const thinkMatches = message?.match(/<think>([\s\S]*?)<\/think>/g) || [];
+    const thoughts = thinkMatches.map(match =>
+      match.replace(/<think>|<\/think>/g, '').trim()
+    );
+
+    // Get the response content without the think tags
+    const responseContent = message?.replace(/<think>[\s\S]*?<\/think>/g, "").trim();
+
     return (
-      <div className="py-[5px]">
+      <div className="allm-py-[5px]">
         {role === "assistant" && (
-          <div
-            className={`allm-text-[10px] allm-text-gray-400 allm-ml-[54px] allm-mr-6 allm-mb-2 allm-text-left allm-font-sans`}
-          >
-            {embedderSettings.settings.assistantName ||
-              "Anything LLM Chat Assistant"}
+          <div className="allm-text-[10px] allm-text-gray-400 allm-ml-[54px] allm-mr-6 allm-mb-2 allm-text-left allm-font-sans">
+            {embedderSettings.settings.assistantName || "Anything LLM Chat Assistant"}
           </div>
         )}
         <div
@@ -47,7 +80,7 @@ const HistoricalMessage = forwardRef(
             <img
               src={embedderSettings.settings.assistantIcon || AnythingLLMIcon}
               alt="Anything LLM Icon"
-              className="allm-w-9 allm-h-9 allm-flex-shrink-0 allm-ml-2 allm-mt-2"
+              className="allm-w-9 allm-h-9 allm-flex-shrink-0 allm-ml-2"
               id="anything-llm-icon"
             />
           )}
@@ -67,10 +100,10 @@ const HistoricalMessage = forwardRef(
                   : `${embedderSettings.ASSISTANT_STYLES.base} allm-anything-llm-assistant-message`
             } allm-shadow-[0_4px_14px_rgba(0,0,0,0.25)]`}
           >
-            <div className="allm-flex">
+            <div className="allm-flex allm-flex-col">
               {error ? (
                 <div className="allm-p-2 allm-rounded-lg allm-bg-red-50 allm-text-red-500">
-                  <span className={`allm-inline-block `}>
+                  <span className="allm-inline-block">
                     <Warning className="allm-h-4 allm-w-4 allm-mb-1 allm-inline-block" />{" "}
                     Could not respond to message.
                   </span>
@@ -79,12 +112,17 @@ const HistoricalMessage = forwardRef(
                   </p>
                 </div>
               ) : (
-                <span
-                  className={`allm-whitespace-pre-line allm-flex allm-flex-col allm-gap-y-1 ${textSize} allm-leading-[20px]`}
-                  dangerouslySetInnerHTML={{
-                    __html: DOMPurify.sanitize(renderMarkdown(message)),
-                  }}
-                />
+                <>
+                  {role === "assistant" && thoughts.length > 0 && (
+                    <ThoughtBubble thought={thoughts.join("\n\n")} />
+                  )}
+                  <span
+                    className={`allm-whitespace-pre-line allm-flex allm-flex-col allm-gap-y-1 ${textSize} allm-leading-[20px]`}
+                    dangerouslySetInnerHTML={{
+                      __html: DOMPurify.sanitize(renderMarkdown(responseContent || message)),
+                    }}
+                  />
+                </>
               )}
             </div>
           </div>

--- a/src/components/ChatWindow/ChatContainer/ChatHistory/PromptReply/index.jsx
+++ b/src/components/ChatWindow/ChatContainer/ChatHistory/PromptReply/index.jsx
@@ -1,19 +1,136 @@
-import { forwardRef, memo } from "react";
-import { Warning } from "@phosphor-icons/react";
+import { forwardRef, memo, useState } from "react";
+import { Warning, CircleNotch, CaretDown } from "@phosphor-icons/react";
 import renderMarkdown from "@/utils/chat/markdown";
 import { embedderSettings } from "@/main";
 import AnythingLLMIcon from "@/assets/anything-llm-icon.svg";
 import { formatDate } from "@/utils/date";
+
+const ThinkingIndicator = ({ hasThought }) => {
+  if (hasThought) {
+    return (
+      <div className="allm-flex allm-items-center allm-gap-x-2 allm-text-gray-500">
+        <CircleNotch size={16} className="allm-animate-spin" />
+        <span className="allm-text-sm">Thinking...</span>
+      </div>
+    );
+  }
+  return <div className="allm-mx-4 allm-my-1 allm-dot-falling"></div>;
+};
+
+const ThoughtBubble = ({ thought }) => {
+  const [isExpanded, setIsExpanded] = useState(false);
+  if (!thought || !embedderSettings.settings.showThoughts) return null;
+
+  const cleanThought = thought.replace(/<\/?think>/g, '').trim();
+
+  return (
+    <div className="allm-mb-2">
+      <div
+        onClick={() => setIsExpanded(!isExpanded)}
+        className="allm-cursor-pointer allm-flex allm-items-center allm-gap-x-1.5 allm-text-gray-400 hover:allm-text-gray-500"
+      >
+        <CaretDown
+          size={14}
+          weight="bold"
+          className={`allm-transition-transform ${isExpanded ? "allm-rotate-180" : ""}`}
+        />
+        <span className="allm-text-xs allm-font-medium">View thoughts</span>
+      </div>
+      {isExpanded && (
+        <div className="allm-mt-2 allm-mb-3 allm-pl-0 allm-border-l-2 allm-border-gray-200">
+          <div className="allm-text-xs allm-text-gray-600 allm-font-mono allm-whitespace-pre-wrap">{cleanThought}</div>
+        </div>
+      )}
+    </div>
+  );
+};
 
 const PromptReply = forwardRef(
   ({ uuid, reply, pending, error, sources = [], sentAt }, ref) => {
     if (!reply && sources.length === 0 && !pending && !error) return null;
     if (error) console.error(`ANYTHING_LLM_CHAT_WIDGET_ERROR: ${error}`);
 
-    if (pending) {
+    // Extract content between think tags if they exist
+    const thinkMatches = reply?.match(/<think>([\s\S]*?)<\/think>/g) || [];
+    const thoughts = thinkMatches.map(match => match.replace(/<\/?think>/g, '').trim());
+
+    const hasIncompleteThinkTag = reply?.includes("<think>") && !reply?.includes("</think>");
+
+    // For incomplete think tags during streaming, extract the content after the opening tag
+    const streamingThought = hasIncompleteThinkTag ?
+      reply?.split('<think>').pop()?.replace(/<\/?think>/g, '').trim() : null;
+
+    const lastThought = streamingThought || thoughts[thoughts.length - 1];
+    const isThinking = hasIncompleteThinkTag || pending;
+
+    // Get the response content without the think tags - clean more aggressively
+    const responseContent = reply?.replace(/<think>[\s\S]*?<\/think>/g, "")  // Remove complete think blocks
+      .replace(/<think>.*$/g, "")  // Remove any incomplete think blocks at the end
+      .replace(/<\/?think>/g, "")  // Remove any stray think tags
+      .trim();
+
+    if (isThinking) {
       return (
+        <div className="allm-py-[5px]">
+          <div className="allm-text-[10px] allm-text-gray-400 allm-ml-[54px] allm-mr-6 allm-mb-2 allm-text-left allm-font-sans">
+            {embedderSettings.settings.assistantName || "Anything LLM Chat Assistant"}
+          </div>
+          <div className="allm-flex allm-items-start allm-w-full allm-h-fit allm-justify-start">
+            <img
+              src={embedderSettings.settings.assistantIcon || AnythingLLMIcon}
+              alt="Anything LLM Icon"
+              className="allm-w-9 allm-h-9 allm-flex-shrink-0 allm-ml-2"
+            />
+            <div
+              style={{
+                wordBreak: "break-word",
+                backgroundColor: embedderSettings.ASSISTANT_STYLES.msgBg,
+              }}
+              className={`allm-py-[11px] allm-px-4 allm-flex allm-flex-col ${embedderSettings.ASSISTANT_STYLES.base} allm-shadow-[0_4px_14px_rgba(0,0,0,0.25)]`}
+            >
+              {hasIncompleteThinkTag && streamingThought && <ThoughtBubble thought={streamingThought} />}
+              <ThinkingIndicator hasThought={hasIncompleteThinkTag} />
+            </div>
+          </div>
+        </div>
+      );
+    }
+
+    if (error) {
+      return (
+        <div className="allm-py-[5px]">
+          <div className="allm-text-[10px] allm-text-gray-400 allm-ml-[54px] allm-mr-6 allm-mb-2 allm-text-left allm-font-sans">
+            {embedderSettings.settings.assistantName || "Anything LLM Chat Assistant"}
+          </div>
+          <div className="allm-flex allm-items-start allm-w-full allm-h-fit allm-justify-start">
+            <img
+              src={embedderSettings.settings.assistantIcon || AnythingLLMIcon}
+              alt="Anything LLM Icon"
+              className="allm-w-9 allm-h-9 allm-flex-shrink-0 allm-ml-2"
+            />
+            <div className="allm-py-[11px] allm-px-4 allm-rounded-lg allm-flex allm-flex-col allm-bg-red-200 allm-shadow-[0_4px_14px_rgba(0,0,0,0.25)] allm-mr-[37px] allm-ml-[9px]">
+              <div className="allm-flex allm-gap-x-5">
+                <span className="allm-inline-block allm-p-2 allm-rounded-lg allm-bg-red-50 allm-text-red-500">
+                  <Warning className="allm-h-4 allm-w-4 allm-mb-1 allm-inline-block" />{" "}
+                  Could not respond to message.
+                  <span className="allm-text-xs">Server error</span>
+                </span>
+              </div>
+            </div>
+          </div>
+        </div>
+      );
+    }
+
+    return (
+      <div className="allm-py-[5px]">
+        <div className="allm-text-[10px] allm-text-gray-400 allm-ml-[54px] allm-mr-6 allm-mb-2 allm-text-left allm-font-sans">
+          {embedderSettings.settings.assistantName || "Anything LLM Chat Assistant"}
+        </div>
         <div
-          className={`allm-flex allm-items-start allm-w-full allm-h-fit allm-justify-start`}
+          key={uuid}
+          ref={ref}
+          className="allm-flex allm-items-start allm-w-full allm-h-fit allm-justify-start"
         >
           <img
             src={embedderSettings.settings.assistantIcon || AnythingLLMIcon}
@@ -27,81 +144,17 @@ const PromptReply = forwardRef(
             }}
             className={`allm-py-[11px] allm-px-4 allm-flex allm-flex-col ${embedderSettings.ASSISTANT_STYLES.base} allm-shadow-[0_4px_14px_rgba(0,0,0,0.25)]`}
           >
-            <div className="allm-flex allm-gap-x-5">
-              <div className="allm-mx-4 allm-my-1 allm-dot-falling"></div>
-            </div>
-          </div>
-        </div>
-      );
-    }
-
-    if (error) {
-      return (
-        <div
-          className={`allm-flex allm-items-end allm-w-full allm-h-fit allm-justify-start`}
-        >
-          <img
-            src={embedderSettings.settings.assistantIcon || AnythingLLMIcon}
-            alt="Anything LLM Icon"
-            className="allm-w-9 allm-h-9 allm-flex-shrink-0 allm-ml-2"
-          />
-          <div
-            style={{ wordBreak: "break-word" }}
-            className={`allm-py-[11px] allm-px-4 allm-rounded-lg allm-flex allm-flex-col allm-bg-red-200 allm-shadow-[0_4px_14px_rgba(0,0,0,0.25)] allm-mr-[37px] allm-ml-[9px]`}
-          >
+            {thoughts.length > 0 && <ThoughtBubble thought={thoughts.join("\n\n")} />}
             <div className="allm-flex allm-gap-x-5">
               <span
-                className={`allm-inline-block allm-p-2 allm-rounded-lg allm-bg-red-50 allm-text-red-500`}
-              >
-                <Warning className="allm-h-4 allm-w-4 allm-mb-1 allm-inline-block" />{" "}
-                Could not respond to message.
-                <span className="allm-text-xs">Server error</span>
-              </span>
-            </div>
-          </div>
-        </div>
-      );
-    }
-
-    return (
-      <div className="allm-py-[5px]">
-        <div
-          className={`allm-text-[10px] allm-text-gray-400 allm-ml-[54px] allm-mr-6 allm-mb-2 allm-text-left allm-font-sans`}
-        >
-          {embedderSettings.settings.assistantName ||
-            "Anything LLM Chat Assistant"}
-        </div>
-        <div
-          key={uuid}
-          ref={ref}
-          className={`allm-flex allm-items-start allm-w-full allm-h-fit allm-justify-start`}
-        >
-          <img
-            src={embedderSettings.settings.assistantIcon || AnythingLLMIcon}
-            alt="Anything LLM Icon"
-            className="allm-w-9 allm-h-9 allm-flex-shrink-0 allm-ml-2"
-          />
-          <div
-            style={{
-              wordBreak: "break-word",
-              backgroundColor: embedderSettings.ASSISTANT_STYLES.msgBg,
-            }}
-            className={`allm-py-[11px] allm-px-4 allm-flex allm-flex-col ${
-              error ? "allm-bg-red-200" : embedderSettings.ASSISTANT_STYLES.base
-            } allm-shadow-[0_4px_14px_rgba(0,0,0,0.25)]`}
-          >
-            <div className="allm-flex allm-gap-x-5">
-              <span
-                className={`allm-font-sans allm-reply allm-whitespace-pre-line allm-font-normal allm-text-sm allm-md:text-sm allm-flex allm-flex-col allm-gap-y-1`}
-                dangerouslySetInnerHTML={{ __html: renderMarkdown(reply) }}
+                className="allm-font-sans allm-reply allm-whitespace-pre-line allm-font-normal allm-text-sm allm-md:text-sm allm-flex allm-flex-col allm-gap-y-1"
+                dangerouslySetInnerHTML={{ __html: renderMarkdown(responseContent || "") }}
               />
             </div>
           </div>
         </div>
         {sentAt && (
-          <div
-            className={`allm-text-[10px] allm-text-gray-400 allm-ml-[54px] allm-mr-6 allm-mt-2 allm-text-left allm-font-sans`}
-          >
+          <div className="allm-text-[10px] allm-text-gray-400 allm-ml-[54px] allm-mr-6 allm-mt-2 allm-text-left allm-font-sans">
             {formatDate(sentAt)}
           </div>
         )}

--- a/src/components/ChatWindow/ChatContainer/ChatHistory/PromptReply/index.jsx
+++ b/src/components/ChatWindow/ChatContainer/ChatHistory/PromptReply/index.jsx
@@ -21,7 +21,7 @@ const ThoughtBubble = ({ thought }) => {
   const [isExpanded, setIsExpanded] = useState(false);
   if (!thought || !embedderSettings.settings.showThoughts) return null;
 
-  const cleanThought = thought.replace(/<\/?think>/g, '').trim();
+  const cleanThought = thought.replace(/<\/?think>/g, "").trim();
 
   return (
     <div className="allm-mb-2">
@@ -38,7 +38,9 @@ const ThoughtBubble = ({ thought }) => {
       </div>
       {isExpanded && (
         <div className="allm-mt-2 allm-mb-3 allm-pl-0 allm-border-l-2 allm-border-gray-200">
-          <div className="allm-text-xs allm-text-gray-600 allm-font-mono allm-whitespace-pre-wrap">{cleanThought}</div>
+          <div className="allm-text-xs allm-text-gray-600 allm-font-mono allm-whitespace-pre-wrap">
+            {cleanThought}
+          </div>
         </div>
       )}
     </div>
@@ -52,28 +54,38 @@ const PromptReply = forwardRef(
 
     // Extract content between think tags if they exist
     const thinkMatches = reply?.match(/<think>([\s\S]*?)<\/think>/g) || [];
-    const thoughts = thinkMatches.map(match => match.replace(/<\/?think>/g, '').trim());
+    const thoughts = thinkMatches.map((match) =>
+      match.replace(/<\/?think>/g, "").trim()
+    );
 
-    const hasIncompleteThinkTag = reply?.includes("<think>") && !reply?.includes("</think>");
+    const hasIncompleteThinkTag =
+      reply?.includes("<think>") && !reply?.includes("</think>");
 
     // For incomplete think tags during streaming, extract the content after the opening tag
-    const streamingThought = hasIncompleteThinkTag ?
-      reply?.split('<think>').pop()?.replace(/<\/?think>/g, '').trim() : null;
+    const streamingThought = hasIncompleteThinkTag
+      ? reply
+          ?.split("<think>")
+          .pop()
+          ?.replace(/<\/?think>/g, "")
+          .trim()
+      : null;
 
     const lastThought = streamingThought || thoughts[thoughts.length - 1];
     const isThinking = hasIncompleteThinkTag || pending;
 
     // Get the response content without the think tags - clean more aggressively
-    const responseContent = reply?.replace(/<think>[\s\S]*?<\/think>/g, "")  // Remove complete think blocks
-      .replace(/<think>.*$/g, "")  // Remove any incomplete think blocks at the end
-      .replace(/<\/?think>/g, "")  // Remove any stray think tags
+    const responseContent = reply
+      ?.replace(/<think>[\s\S]*?<\/think>/g, "") // Remove complete think blocks
+      .replace(/<think>.*$/g, "") // Remove any incomplete think blocks at the end
+      .replace(/<\/?think>/g, "") // Remove any stray think tags
       .trim();
 
     if (isThinking) {
       return (
         <div className="allm-py-[5px]">
           <div className="allm-text-[10px] allm-text-gray-400 allm-ml-[54px] allm-mr-6 allm-mb-2 allm-text-left allm-font-sans">
-            {embedderSettings.settings.assistantName || "Anything LLM Chat Assistant"}
+            {embedderSettings.settings.assistantName ||
+              "Anything LLM Chat Assistant"}
           </div>
           <div className="allm-flex allm-items-start allm-w-full allm-h-fit allm-justify-start">
             <img
@@ -88,7 +100,9 @@ const PromptReply = forwardRef(
               }}
               className={`allm-py-[11px] allm-px-4 allm-flex allm-flex-col ${embedderSettings.ASSISTANT_STYLES.base} allm-shadow-[0_4px_14px_rgba(0,0,0,0.25)]`}
             >
-              {hasIncompleteThinkTag && streamingThought && <ThoughtBubble thought={streamingThought} />}
+              {hasIncompleteThinkTag && streamingThought && (
+                <ThoughtBubble thought={streamingThought} />
+              )}
               <ThinkingIndicator hasThought={hasIncompleteThinkTag} />
             </div>
           </div>
@@ -100,7 +114,8 @@ const PromptReply = forwardRef(
       return (
         <div className="allm-py-[5px]">
           <div className="allm-text-[10px] allm-text-gray-400 allm-ml-[54px] allm-mr-6 allm-mb-2 allm-text-left allm-font-sans">
-            {embedderSettings.settings.assistantName || "Anything LLM Chat Assistant"}
+            {embedderSettings.settings.assistantName ||
+              "Anything LLM Chat Assistant"}
           </div>
           <div className="allm-flex allm-items-start allm-w-full allm-h-fit allm-justify-start">
             <img
@@ -125,7 +140,8 @@ const PromptReply = forwardRef(
     return (
       <div className="allm-py-[5px]">
         <div className="allm-text-[10px] allm-text-gray-400 allm-ml-[54px] allm-mr-6 allm-mb-2 allm-text-left allm-font-sans">
-          {embedderSettings.settings.assistantName || "Anything LLM Chat Assistant"}
+          {embedderSettings.settings.assistantName ||
+            "Anything LLM Chat Assistant"}
         </div>
         <div
           key={uuid}
@@ -144,11 +160,15 @@ const PromptReply = forwardRef(
             }}
             className={`allm-py-[11px] allm-px-4 allm-flex allm-flex-col ${embedderSettings.ASSISTANT_STYLES.base} allm-shadow-[0_4px_14px_rgba(0,0,0,0.25)]`}
           >
-            {thoughts.length > 0 && <ThoughtBubble thought={thoughts.join("\n\n")} />}
+            {thoughts.length > 0 && (
+              <ThoughtBubble thought={thoughts.join("\n\n")} />
+            )}
             <div className="allm-flex allm-gap-x-5">
               <span
                 className="allm-font-sans allm-reply allm-whitespace-pre-line allm-font-normal allm-text-sm allm-md:text-sm allm-flex allm-flex-col allm-gap-y-1"
-                dangerouslySetInnerHTML={{ __html: renderMarkdown(responseContent || "") }}
+                dangerouslySetInnerHTML={{
+                  __html: renderMarkdown(responseContent || ""),
+                }}
               />
             </div>
           </div>

--- a/src/components/ChatWindow/ChatContainer/ChatHistory/index.jsx
+++ b/src/components/ChatWindow/ChatContainer/ChatHistory/index.jsx
@@ -48,7 +48,7 @@ export default function ChatHistory({ settings = {}, history = [] }) {
 
   if (history.length === 0) {
     return (
-      <div className="allm-pb-[100px] allm-pt-[5px] allm-rounded-lg allm-px-2 allm-h-full allm-mt-2 allm-gap-y-2 allm-overflow-y-scroll allm-flex allm-flex-col allm-justify-start allm-no-scroll">
+      <div className="allm-h-full allm-overflow-y-auto allm-px-2 allm-py-4 allm-flex allm-flex-col allm-justify-start allm-no-scroll">
         <div className="allm-flex allm-h-full allm-flex-col allm-items-center allm-justify-center">
           <p className="allm-text-slate-400 allm-text-sm allm-font-sans allm-py-4 allm-text-center">
             {settings?.greeting ?? "Send a chat to get started."}
@@ -61,52 +61,54 @@ export default function ChatHistory({ settings = {}, history = [] }) {
 
   return (
     <div
-      className="allm-pb-[30px] allm-pt-[5px] allm-rounded-lg allm-px-2 allm-h-full allm-gap-y-2 allm-overflow-y-scroll allm-flex allm-flex-col allm-justify-start allm-no-scroll allm-md:max-h-[500px]"
+      className="allm-h-full allm-overflow-y-auto allm-px-2 allm-pt-4 allm-pb-8 allm-flex allm-flex-col allm-justify-start allm-no-scroll"
       id="chat-history"
       ref={chatHistoryRef}
     >
-      {history.map((props, index) => {
-        const isLastMessage = index === history.length - 1;
-        const isLastBotReply =
-          index === history.length - 1 && props.role === "assistant";
+      <div className="allm-flex allm-flex-col allm-gap-y-4">
+        {history.map((props, index) => {
+          const isLastMessage = index === history.length - 1;
+          const isLastBotReply =
+            index === history.length - 1 && props.role === "assistant";
 
-        if (isLastBotReply && props.animate) {
+          if (isLastBotReply && props.animate) {
+            return (
+              <PromptReply
+                key={props.uuid}
+                ref={isLastMessage ? replyRef : null}
+                uuid={props.uuid}
+                reply={props.content}
+                pending={props.pending}
+                sources={props.sources}
+                error={props.error}
+                closed={props.closed}
+              />
+            );
+          }
+
           return (
-            <PromptReply
-              key={props.uuid}
+            <HistoricalMessage
+              key={index}
               ref={isLastMessage ? replyRef : null}
-              uuid={props.uuid}
-              reply={props.content}
-              pending={props.pending}
+              message={props.content}
+              sentAt={props.sentAt || Date.now() / 1000}
+              role={props.role}
               sources={props.sources}
+              chatId={props.chatId}
+              feedbackScore={props.feedbackScore}
               error={props.error}
-              closed={props.closed}
+              errorMsg={props.errorMsg}
             />
           );
-        }
-
-        return (
-          <HistoricalMessage
-            key={index}
-            ref={isLastMessage ? replyRef : null}
-            message={props.content}
-            sentAt={props.sentAt || Date.now() / 1000}
-            role={props.role}
-            sources={props.sources}
-            chatId={props.chatId}
-            feedbackScore={props.feedbackScore}
-            error={props.error}
-            errorMsg={props.errorMsg}
-          />
-        );
-      })}
+        })}
+      </div>
       {!isAtBottom && (
         <div className="allm-fixed allm-bottom-[10rem] allm-right-[50px] allm-z-50 allm-cursor-pointer allm-animate-pulse">
           <div className="allm-flex allm-flex-col allm-items-center">
-            <div className="allm-p-1 allm-rounded-full allm-border allm-border-white/10 allm-bg-black/20 hover:allm-bg-black/50">
+            <div className="allm-rounded-full allm-border allm-border-white/10 allm-bg-black/20 hover:allm-bg-black/50 allm-w-8 allm-h-8 allm-flex allm-items-center allm-justify-center">
               <ArrowDown
                 weight="bold"
-                className="allm-text-white/50 allm-w-5 allm-h-5"
+                className="allm-text-white/50 allm-w-4 allm-h-4"
                 onClick={scrollToBottom}
                 id="scroll-to-bottom-button"
                 aria-label="Scroll to bottom"

--- a/src/components/ChatWindow/ChatContainer/index.jsx
+++ b/src/components/ChatWindow/ChatContainer/index.jsx
@@ -131,16 +131,18 @@ export default function ChatContainer({
 
   return (
     <div className="allm-h-full allm-w-full allm-flex allm-flex-col">
-      <div className="allm-flex-grow allm-overflow-y-auto">
+      <div className="allm-flex-1 allm-min-h-0 allm-mb-8">
         <ChatHistory settings={settings} history={chatHistory} />
       </div>
-      <PromptInput
-        message={message}
-        submit={handleSubmit}
-        onChange={handleMessageChange}
-        inputDisabled={loadingResponse}
-        buttonDisabled={loadingResponse}
-      />
+      <div className="allm-flex-shrink-0 allm-mt-auto">
+        <PromptInput
+          message={message}
+          submit={handleSubmit}
+          onChange={handleMessageChange}
+          inputDisabled={loadingResponse}
+          buttonDisabled={loadingResponse}
+        />
+      </div>
     </div>
   );
 }

--- a/src/hooks/useScriptAttributes.js
+++ b/src/hooks/useScriptAttributes.js
@@ -9,6 +9,7 @@ const DEFAULT_SETTINGS = {
   prompt: null, // override
   model: null, // override
   temperature: null, //override
+  showThoughts: false, // show the AI's thought process in responses.
 
   // style parameters
   chatIcon: "plus",

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -3,8 +3,13 @@ import ReactDOM from "react-dom/client";
 import App from "./App.jsx";
 import "./index.css";
 import { parseStylesSrc } from "./utils/constants.js";
-const appElement = document.createElement("div");
 
+const scriptSettings = Object.assign(
+  {},
+  document?.currentScript?.dataset || {}
+);
+
+const appElement = document.createElement("div");
 document.body.appendChild(appElement);
 const root = ReactDOM.createRoot(appElement);
 root.render(
@@ -13,12 +18,11 @@ root.render(
   </React.StrictMode>
 );
 
-const scriptSettings = Object.assign(
-  {},
-  document?.currentScript?.dataset || {}
-);
 export const embedderSettings = {
-  settings: scriptSettings,
+  settings: {
+    ...scriptSettings,
+    showThoughts: scriptSettings.showThoughts !== "false",
+  },
   stylesSrc: parseStylesSrc(document?.currentScript?.src),
   USER_STYLES: {
     msgBg: scriptSettings?.userBgColor ?? "#3DBEF5",

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -3,13 +3,8 @@ import ReactDOM from "react-dom/client";
 import App from "./App.jsx";
 import "./index.css";
 import { parseStylesSrc } from "./utils/constants.js";
-
-const scriptSettings = Object.assign(
-  {},
-  document?.currentScript?.dataset || {}
-);
-
 const appElement = document.createElement("div");
+
 document.body.appendChild(appElement);
 const root = ReactDOM.createRoot(appElement);
 root.render(
@@ -18,10 +13,12 @@ root.render(
   </React.StrictMode>
 );
 
+const scriptSettings = Object.assign(
+  {},
+  document?.currentScript?.dataset || {}
+);
 export const embedderSettings = {
-  settings: {
-    ...scriptSettings,
-  },
+  settings: scriptSettings,
   stylesSrc: parseStylesSrc(document?.currentScript?.src),
   USER_STYLES: {
     msgBg: scriptSettings?.userBgColor ?? "#3DBEF5",

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -21,7 +21,6 @@ root.render(
 export const embedderSettings = {
   settings: {
     ...scriptSettings,
-    showThoughts: scriptSettings.showThoughts !== "false",
   },
   stylesSrc: parseStylesSrc(document?.currentScript?.src),
   USER_STYLES: {


### PR DESCRIPTION
- Fix unnatural containers in embedded chat widget (scrolling inside of 2 containers)
- Fix UI of scroll down button
- Implement option to hide/show thoughts from thinking models in embed chat settings
- Added new thinking state that shows in embed widget when `<think>` tag detected
- Added collapsable menu to hide/show thoughts during streaming and after message is complete
- Support `data-show-thoughts` attribute in embed chat widget to enable/disable option via HTML

connects https://github.com/Mintplex-Labs/anything-llm/issues/3339