### PR TITLE
Add i18n support and send message/reset chat data attributes

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,10 @@ REQUIRED data attributes:
 
 - `data-temperature` — Override the chat model temperature. This must be a valid value for your AnythingLLM LLM provider. If unset it will use the embeds attached workspace model temperature or the system setting.
 
+**Language & Localization**
+
+- `data-language` — Set the language for the chat interface. If not specified, it will default to English (en). Currently supported languages: en (English).
+
 **Style Overrides**
 
 - `data-chat-icon` — The chat bubble icon show when chat is closed. Options are `plus`, `chatBubble`, `support`, `search2`, `search`, `magic`.
@@ -96,6 +100,10 @@ REQUIRED data attributes:
 - `data-username` - A specific readable name or identifier for the client for your reference. Will be shown in AnythingLLM chat logs. If empty it will not be reported.
 
 - `data-default-messages` - A string of comma-separated messages you want to display to the user when the chat widget has no history. Example: `"How are you?, What is so interesting about this project?, Tell me a joke."`
+
+- `data-send-message-text` — Override the placeholder text in the message input field. If not specified, it will use the translated text based on the selected language.
+
+- `data-reset-chat-text` — Override the text shown on the reset chat button. If not specified, it will use the translated text based on the selected language.
 
 **Behavior Overrides**
 

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ REQUIRED data attributes:
 ></script>
 ```
 
-### `<script>` Customization Options
+## `<script>` Customization Options
 
 **LLM Overrides**
 
@@ -63,7 +63,7 @@ REQUIRED data attributes:
 
 **Language & Localization**
 
-- `data-language` — Set the language for the chat interface. If not specified, it will default to English (en). Currently supported languages: en (English).
+- `data-language` — Set the language for the chat interface. If not specified, it will default to English (en). [Currently supported languages are available here](https://github.com/Mintplex-Labs/anythingllm-embed/main/src/locales/resources.js). (PR's welcome)
 
 **Style Overrides**
 
@@ -101,9 +101,9 @@ REQUIRED data attributes:
 
 - `data-default-messages` - A string of comma-separated messages you want to display to the user when the chat widget has no history. Example: `"How are you?, What is so interesting about this project?, Tell me a joke."`
 
-- `data-send-message-text` — Override the placeholder text in the message input field. If not specified, it will use the translated text based on the selected language.
+- `data-send-message-text` — Override the placeholder text in the message input field.
 
-- `data-reset-chat-text` — Override the text shown on the reset chat button. If not specified, it will use the translated text based on the selected language.
+- `data-reset-chat-text` — Override the text shown on the reset chat button.
 
 **Behavior Overrides**
 

--- a/index.html
+++ b/index.html
@@ -12,17 +12,6 @@
       src="/dist/anythingllm-chat-widget.js"> USE THIS SRC FOR DEVELOPMENT SO CHANGES APPEAR!
       </script>
     -->
-
-    <!--
-Paste this script at the bottom of your HTML before the </body> tag.
-See more style and config options on our docs
-https://github.com/Mintplex-Labs/anything-llm/tree/master/embed/README.md
--->
-    <script data-embed-id="3b6eb5f2-9b5b-419a-9953-2a9dfe8de3c1" data-base-api-url="http://localhost:3001/api/embed"
-      src="/dist/anythingllm-chat-widget.js">
-      </script>
-    <!-- AnythingLLM (https://anythingllm.com) -->
-
   </body>
 
 </html>

--- a/index.html
+++ b/index.html
@@ -12,6 +12,17 @@
       src="/dist/anythingllm-chat-widget.js"> USE THIS SRC FOR DEVELOPMENT SO CHANGES APPEAR!
       </script>
     -->
+
+    <!--
+Paste this script at the bottom of your HTML before the </body> tag.
+See more style and config options on our docs
+https://github.com/Mintplex-Labs/anything-llm/tree/master/embed/README.md
+-->
+    <script data-embed-id="3b6eb5f2-9b5b-419a-9953-2a9dfe8de3c1" data-base-api-url="http://localhost:3001/api/embed"
+      src="/dist/anythingllm-chat-widget.js">
+      </script>
+    <!-- AnythingLLM (https://anythingllm.com) -->
+
   </body>
 
 </html>

--- a/package.json
+++ b/package.json
@@ -24,7 +24,10 @@
     "markdown-it": "^13.0.1",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
-    "uuid": "^9.0.1"
+    "uuid": "^9.0.1",
+    "i18next": "^23.11.3",
+    "react-i18next": "^14.1.1",
+    "i18next-browser-languagedetector": "^7.2.1"
   },
   "devDependencies": {
     "@rollup/plugin-image": "^3.0.3",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,9 @@
     "build:publish": "yarn build:publish:js && yarn build:publish:css",
     "build:publish:js": "yarn build && mkdir -p ../frontend/public/embed && cp -r dist/anythingllm-chat-widget.min.js ../frontend/public/embed/anythingllm-chat-widget.min.js",
     "build:publish:css": "cp -r dist/anythingllm-chat-widget.min.css ../frontend/public/embed/anythingllm-chat-widget.min.css",
-    "lint": "yarn prettier --ignore-path ../.prettierignore --write ./src"
+    "lint": "yarn prettier --ignore-path ../.prettierignore --write ./src",
+    "verify:translations": "cd src/locales && node verifyTranslations.mjs",
+    "normalize:translations": "cd src/locales && node normalizeEn.mjs"
   },
   "dependencies": {
     "@microsoft/fetch-event-source": "^2.0.1",

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -5,6 +5,8 @@ import Head from "@/components/Head";
 import OpenButton from "@/components/OpenButton";
 import ChatWindow from "./components/ChatWindow";
 import { useEffect } from "react";
+import { I18nextProvider } from "react-i18next";
+import i18next from "@/i18n";
 
 export default function App() {
   const { isChatOpen, toggleOpenChat } = useOpenChat();
@@ -31,7 +33,7 @@ export default function App() {
   const windowHeight = embedSettings.windowHeight ?? "700px";
 
   return (
-    <>
+    <I18nextProvider i18n={i18next}>
       <Head />
       <div
         id="anything-llm-embed-chat-container"
@@ -67,6 +69,6 @@ export default function App() {
           />
         </div>
       )}
-    </>
+    </I18nextProvider>
   );
 }

--- a/src/components/ChatWindow/ChatContainer/PromptInput/index.jsx
+++ b/src/components/ChatWindow/ChatContainer/PromptInput/index.jsx
@@ -1,5 +1,7 @@
 import { CircleNotch, PaperPlaneRight } from "@phosphor-icons/react";
 import React, { useState, useRef, useEffect } from "react";
+import { useTranslation } from "react-i18next";
+import { embedderSettings } from "@/main.jsx";
 
 export default function PromptInput({
   message,
@@ -8,6 +10,7 @@ export default function PromptInput({
   inputDisabled,
   buttonDisabled,
 }) {
+  const { t } = useTranslation();
   const formRef = useRef(null);
   const textareaRef = useRef(null);
   const [_, setFocused] = useState(false);
@@ -71,7 +74,10 @@ export default function PromptInput({
                 }}
                 value={message}
                 className="allm-font-sans allm-border-none allm-cursor-text allm-max-h-[100px] allm-text-[14px] allm-mx-2 allm-py-2 allm-w-full allm-text-black allm-bg-transparent placeholder:allm-text-slate-800/60 allm-resize-none active:allm-outline-none focus:allm-outline-none allm-flex-grow"
-                placeholder={"Send a message"}
+                placeholder={
+                  embedderSettings.settings.sendMessageText ||
+                  t("chat.send-message")
+                }
                 id="message-input"
               />
               <button

--- a/src/components/ChatWindow/ChatContainer/PromptInput/index.jsx
+++ b/src/components/ChatWindow/ChatContainer/PromptInput/index.jsx
@@ -1,9 +1,9 @@
 import { CircleNotch, PaperPlaneRight } from "@phosphor-icons/react";
 import React, { useState, useRef, useEffect } from "react";
 import { useTranslation } from "react-i18next";
-import { embedderSettings } from "@/main.jsx";
 
 export default function PromptInput({
+  settings,
   message,
   submit,
   onChange,
@@ -74,10 +74,7 @@ export default function PromptInput({
                 }}
                 value={message}
                 className="allm-font-sans allm-border-none allm-cursor-text allm-max-h-[100px] allm-text-[14px] allm-mx-2 allm-py-2 allm-w-full allm-text-black allm-bg-transparent placeholder:allm-text-slate-800/60 allm-resize-none active:allm-outline-none focus:allm-outline-none allm-flex-grow"
-                placeholder={
-                  embedderSettings.settings.sendMessageText ||
-                  t("chat.send-message")
-                }
+                placeholder={settings.sendMessageText || t("chat.send-message")}
                 id="message-input"
               />
               <button

--- a/src/components/ChatWindow/ChatContainer/index.jsx
+++ b/src/components/ChatWindow/ChatContainer/index.jsx
@@ -136,6 +136,7 @@ export default function ChatContainer({
       </div>
       <div className="allm-flex-shrink-0 allm-mt-auto">
         <PromptInput
+          settings={settings}
           message={message}
           submit={handleSubmit}
           onChange={handleMessageChange}

--- a/src/components/ResetChat/index.jsx
+++ b/src/components/ResetChat/index.jsx
@@ -1,6 +1,10 @@
 import ChatService from "@/models/chatService";
+import { useTranslation } from "react-i18next";
+import { embedderSettings } from "@/main.jsx";
 
 export default function ResetChat({ setChatHistory, settings, sessionId }) {
+  const { t } = useTranslation();
+
   const handleChatReset = async () => {
     await ChatService.resetEmbedChatSession(settings, sessionId);
     setChatHistory([]);
@@ -13,7 +17,7 @@ export default function ResetChat({ setChatHistory, settings, sessionId }) {
         className="hover:allm-cursor-pointer allm-border-none allm-text-sm allm-bg-transparent hover:allm-opacity-80 hover:allm-underline"
         onClick={() => handleChatReset()}
       >
-        Reset Chat
+        {embedderSettings.settings.resetChatText || t("chat.reset-chat")}
       </button>
     </div>
   );

--- a/src/components/ResetChat/index.jsx
+++ b/src/components/ResetChat/index.jsx
@@ -1,6 +1,5 @@
 import ChatService from "@/models/chatService";
 import { useTranslation } from "react-i18next";
-import { embedderSettings } from "@/main.jsx";
 
 export default function ResetChat({ setChatHistory, settings, sessionId }) {
   const { t } = useTranslation();
@@ -17,7 +16,7 @@ export default function ResetChat({ setChatHistory, settings, sessionId }) {
         className="hover:allm-cursor-pointer allm-border-none allm-text-sm allm-bg-transparent hover:allm-opacity-80 hover:allm-underline"
         onClick={() => handleChatReset()}
       >
-        {embedderSettings.settings.resetChatText || t("chat.reset-chat")}
+        {settings.resetChatText || t("chat.reset-chat")}
       </button>
     </div>
   );

--- a/src/hooks/useScriptAttributes.js
+++ b/src/hooks/useScriptAttributes.js
@@ -27,6 +27,9 @@ const DEFAULT_SETTINGS = {
   windowHeight: null, // height of chat window in number:css-prefix
   windowWidth: null, // width of chat window in number:css-prefix
   textSize: null, // text size in px (number only)
+  language: "en", // language of chat interface
+  sendMessageText: null, // override text for send message button
+  resetChatText: null, // override text for reset chat button
 
   // behaviors
   openOnLoad: "off", // or "on"

--- a/src/i18n.js
+++ b/src/i18n.js
@@ -16,9 +16,10 @@ export function initI18n(settings) {
       defaultNS,
       resources,
       load: "languageOnly",
+      lowerCaseLng: true,
       detection: {
-        order: ["querystring", "navigator"],
-        lookupQuerystring: "lng",
+        order: ["localStorage", "navigator"],
+        lookupLocalStorage: "allm_embed_language",
       },
       interpolation: {
         escapeValue: false,

--- a/src/i18n.js
+++ b/src/i18n.js
@@ -1,0 +1,31 @@
+import i18next from "i18next";
+import { initReactI18next } from "react-i18next";
+import LanguageDetector from "i18next-browser-languagedetector";
+import { defaultNS, resources } from "./locales/resources.js";
+
+export function initI18n(settings) {
+  const language = settings?.language || "en";
+
+  i18next
+    .use(initReactI18next)
+    .use(LanguageDetector)
+    .init({
+      fallbackLng: "en",
+      lng: language,
+      debug: import.meta.env.DEV,
+      defaultNS,
+      resources,
+      load: "languageOnly",
+      detection: {
+        order: ["querystring", "navigator"],
+        lookupQuerystring: "lng",
+      },
+      interpolation: {
+        escapeValue: false,
+      },
+    });
+
+  return i18next;
+}
+
+export default i18next;

--- a/src/locales/ar/common.js
+++ b/src/locales/ar/common.js
@@ -1,0 +1,9 @@
+// Anything with "null" requires a translation. Contribute to translation via a PR!
+const TRANSLATIONS = {
+  chat: {
+    "send-message": null,
+    "reset-chat": null,
+  },
+};
+
+export default TRANSLATIONS;

--- a/src/locales/da/common.js
+++ b/src/locales/da/common.js
@@ -1,0 +1,9 @@
+// Anything with "null" requires a translation. Contribute to translation via a PR!
+const TRANSLATIONS = {
+  chat: {
+    "send-message": null,
+    "reset-chat": null,
+  },
+};
+
+export default TRANSLATIONS;

--- a/src/locales/de/common.js
+++ b/src/locales/de/common.js
@@ -1,0 +1,9 @@
+// Anything with "null" requires a translation. Contribute to translation via a PR!
+const TRANSLATIONS = {
+  chat: {
+    "send-message": null,
+    "reset-chat": null,
+  },
+};
+
+export default TRANSLATIONS;

--- a/src/locales/en/common.js
+++ b/src/locales/en/common.js
@@ -1,0 +1,8 @@
+const TRANSLATIONS = {
+  chat: {
+    "send-message": "Send a message",
+    "reset-chat": "Reset Chat",
+  },
+};
+
+export default TRANSLATIONS;

--- a/src/locales/es/common.js
+++ b/src/locales/es/common.js
@@ -1,0 +1,9 @@
+// Anything with "null" requires a translation. Contribute to translation via a PR!
+const TRANSLATIONS = {
+  chat: {
+    "send-message": null,
+    "reset-chat": null,
+  },
+};
+
+export default TRANSLATIONS;

--- a/src/locales/fa/common.js
+++ b/src/locales/fa/common.js
@@ -1,0 +1,9 @@
+// Anything with "null" requires a translation. Contribute to translation via a PR!
+const TRANSLATIONS = {
+  chat: {
+    "send-message": null,
+    "reset-chat": null,
+  },
+};
+
+export default TRANSLATIONS;

--- a/src/locales/fr/common.js
+++ b/src/locales/fr/common.js
@@ -1,0 +1,8 @@
+const TRANSLATIONS = {
+  chat: {
+    "send-message": "Envoyer un message",
+    "reset-chat": "Réinitialiser la conversation",
+  },
+};
+
+export default TRANSLATIONS;

--- a/src/locales/fr/common.js
+++ b/src/locales/fr/common.js
@@ -1,3 +1,4 @@
+// Anything with "null" requires a translation. Contribute to translation via a PR!
 const TRANSLATIONS = {
   chat: {
     "send-message": "Envoyer un message",

--- a/src/locales/he/common.js
+++ b/src/locales/he/common.js
@@ -1,0 +1,9 @@
+// Anything with "null" requires a translation. Contribute to translation via a PR!
+const TRANSLATIONS = {
+  chat: {
+    "send-message": null,
+    "reset-chat": null,
+  },
+};
+
+export default TRANSLATIONS;

--- a/src/locales/it/common.js
+++ b/src/locales/it/common.js
@@ -1,0 +1,9 @@
+// Anything with "null" requires a translation. Contribute to translation via a PR!
+const TRANSLATIONS = {
+  chat: {
+    "send-message": null,
+    "reset-chat": null,
+  },
+};
+
+export default TRANSLATIONS;

--- a/src/locales/ja/common.js
+++ b/src/locales/ja/common.js
@@ -1,0 +1,9 @@
+// Anything with "null" requires a translation. Contribute to translation via a PR!
+const TRANSLATIONS = {
+  chat: {
+    "send-message": null,
+    "reset-chat": null,
+  },
+};
+
+export default TRANSLATIONS;

--- a/src/locales/ko/common.js
+++ b/src/locales/ko/common.js
@@ -1,0 +1,9 @@
+// Anything with "null" requires a translation. Contribute to translation via a PR!
+const TRANSLATIONS = {
+  chat: {
+    "send-message": null,
+    "reset-chat": null,
+  },
+};
+
+export default TRANSLATIONS;

--- a/src/locales/nl/common.js
+++ b/src/locales/nl/common.js
@@ -1,0 +1,9 @@
+// Anything with "null" requires a translation. Contribute to translation via a PR!
+const TRANSLATIONS = {
+  chat: {
+    "send-message": null,
+    "reset-chat": null,
+  },
+};
+
+export default TRANSLATIONS;

--- a/src/locales/normalizeEn.mjs
+++ b/src/locales/normalizeEn.mjs
@@ -1,0 +1,157 @@
+// This script is used to normalize the translations files to ensure they are all the same.
+// This will take the en file and compare it to all other files and ensure they are all the same.
+// If a non-en file is missing a key, it will be added to the file and set to null
+import { resources } from "./resources.js";
+import fs from "fs";
+const languageNames = new Intl.DisplayNames(Object.keys(resources), {
+  type: "language",
+});
+
+function langDisplayName(lang) {
+  return languageNames.of(lang);
+}
+
+function compareStructures(lang, a, b, subdir = null) {
+  //if a and b aren't the same type, they can't be equal
+  if (typeof a !== typeof b && a !== null && b !== null) {
+    console.log("Invalid type comparison", [
+      {
+        lang,
+        a: typeof a,
+        b: typeof b,
+        values: {
+          a,
+          b,
+        },
+        ...(!!subdir ? { subdir } : {}),
+      },
+    ]);
+    return false;
+  }
+
+  // Need the truthy guard because
+  // typeof null === 'object'
+  if (a && typeof a === "object") {
+    var keysA = Object.keys(a).sort(),
+      keysB = Object.keys(b).sort();
+
+    //if a and b are objects with different no of keys, unequal
+    if (keysA.length !== keysB.length) {
+      console.log("Keys are missing!", {
+        [lang]: keysA,
+        en: keysB,
+        ...(!!subdir ? { subdir } : {}),
+        diff: {
+          added: keysB.filter((key) => !keysA.includes(key)),
+          removed: keysA.filter((key) => !keysB.includes(key)),
+        },
+      });
+      return false;
+    }
+
+    //if keys aren't all the same, unequal
+    if (
+      !keysA.every(function (k, i) {
+        return k === keysB[i];
+      })
+    ) {
+      console.log("Keys are not equal!", {
+        [lang]: keysA,
+        en: keysB,
+        ...(!!subdir ? { subdir } : {}),
+      });
+      return false;
+    }
+
+    //recurse on the values for each key
+    return keysA.every(function (key) {
+      //if we made it here, they have identical keys
+      return compareStructures(lang, a[key], b[key], key);
+    });
+
+    //for primitives just ignore since we don't check values.
+  } else {
+    return true;
+  }
+}
+
+function normalizeTranslations(lang, source, target, subdir = null) {
+  // Handle primitives - if target exists, keep it, otherwise set null
+  if (!source || typeof source !== "object") {
+    return target ?? null;
+  }
+
+  // Handle objects
+  const normalized = target && typeof target === "object" ? { ...target } : {};
+
+  // Add all keys from source (English), setting to null if missing
+  for (const key of Object.keys(source)) {
+    normalized[key] = normalizeTranslations(
+      lang,
+      source[key],
+      normalized[key],
+      key
+    );
+  }
+
+  return normalized;
+}
+
+function ISOToFilename(lang) {
+  const ISO_TO_FILENAME = {
+    "zh-tw": "zh_TW",
+    pt: "pt_BR",
+    vi: "vn",
+  };
+  return ISO_TO_FILENAME[lang] || lang.replace("-", "_");
+}
+
+const failed = [];
+const TRANSLATIONS = {};
+for (const [lang, { common }] of Object.entries(resources)) {
+  TRANSLATIONS[lang] = common;
+}
+
+const PRIMARY = { ...TRANSLATIONS["en"] };
+delete TRANSLATIONS["en"];
+
+console.log(
+  `The following translation files will be normalized against the English file: [${Object.keys(
+    TRANSLATIONS
+  ).join(",")}]`
+);
+
+// Normalize each non-English translation
+for (const [lang, translations] of Object.entries(TRANSLATIONS)) {
+  const normalized = normalizeTranslations(lang, PRIMARY, translations);
+
+  // Update the translations in resources
+  resources[lang].common = normalized;
+
+  // Verify the structure matches
+  const passed = compareStructures(lang, normalized, PRIMARY);
+  console.log(`${langDisplayName(lang)} (${lang}): ${passed ? "✅" : "❌"}`);
+  !passed && failed.push(lang);
+
+  const langFilename = ISOToFilename(lang);
+  fs.writeFileSync(
+    `./${langFilename}/common.js`,
+    `// Anything with "null" requires a translation. Contribute to translation via a PR!
+const TRANSLATIONS = ${JSON.stringify(normalized, null, 2)}
+
+export default TRANSLATIONS;`
+  );
+}
+
+if (failed.length !== 0) {
+  throw new Error(
+    `Error verifying normalized translations. Please check the logs.`,
+    failed
+  );
+}
+
+console.log(
+  `👍 All translation files have been normalized to match the English schema!`
+);
+
+process.exit(0);

--- a/src/locales/pt_BR/common.js
+++ b/src/locales/pt_BR/common.js
@@ -1,0 +1,9 @@
+// Anything with "null" requires a translation. Contribute to translation via a PR!
+const TRANSLATIONS = {
+  chat: {
+    "send-message": null,
+    "reset-chat": null,
+  },
+};
+
+export default TRANSLATIONS;

--- a/src/locales/resources.js
+++ b/src/locales/resources.js
@@ -1,11 +1,92 @@
+// Looking for a language to translate AnythingLLM to?
+// Create a `common.js` file in the language's ISO code https://www.w3.org/International/O-charset-lang.html
+// eg: Spanish => es/common.js
+// eg: French => fr/common.js
+// You should copy the en/common.js file as your template and just translate every string in there.
+// By default, we try to see what the browsers native language is set to and use that. If a string
+// is not defined or is null in the translation file, it will fallback to the value in the en/common.js file
+// RULES:
+// The EN translation file is the ground-truth for what keys and options are available. DO NOT add a special key
+// to a specific language file as this will break the other languages. Any new keys should be added to english
+// and the language file you are working on.
+
+// Contributor Notice: If you are adding a translation you MUST locally run `yarn verify:translations` from the root prior to PR.
+// please do not submit PR's without first verifying this test passes as it will tell you about missing keys or values
+// from the primary dictionary.
+
 import English from "./en/common.js";
+import Korean from "./ko/common.js";
+import Spanish from "./es/common.js";
 import French from "./fr/common.js";
+import Mandarin from "./zh/common.js";
+import German from "./de/common.js";
+import Russian from "./ru/common.js";
+import Italian from "./it/common.js";
+import Portuguese from "./pt_BR/common.js";
+import Hebrew from "./he/common.js";
+import Dutch from "./nl/common.js";
+import Vietnamese from "./vn/common.js";
+import TraditionalChinese from "./zh_TW/common.js";
+import Farsi from "./fa/common.js";
+import Turkish from "./tr/common.js";
+import Arabic from "./ar/common.js";
+import Danish from "./da/common.js";
+import Japanese from "./ja/common.js";
+
 export const defaultNS = "common";
 export const resources = {
   en: {
     common: English,
   },
+  zh: {
+    common: Mandarin,
+  },
+  "zh-tw": {
+    common: TraditionalChinese,
+  },
+  es: {
+    common: Spanish,
+  },
+  de: {
+    common: German,
+  },
   fr: {
     common: French,
+  },
+  ko: {
+    common: Korean,
+  },
+  ru: {
+    common: Russian,
+  },
+  it: {
+    common: Italian,
+  },
+  pt: {
+    common: Portuguese,
+  },
+  he: {
+    common: Hebrew,
+  },
+  nl: {
+    common: Dutch,
+  },
+  vi: {
+    common: Vietnamese,
+  },
+  fa: {
+    common: Farsi,
+  },
+  tr: {
+    common: Turkish,
+  },
+  ar: {
+    common: Arabic,
+  },
+  da: {
+    common: Danish,
+  },
+  ja: {
+    common: Japanese,
   },
 };

--- a/src/locales/resources.js
+++ b/src/locales/resources.js
@@ -1,0 +1,11 @@
+import English from "./en/common.js";
+import French from "./fr/common.js";
+export const defaultNS = "common";
+export const resources = {
+  en: {
+    common: English,
+  },
+  fr: {
+    common: French,
+  },
+};

--- a/src/locales/ru/common.js
+++ b/src/locales/ru/common.js
@@ -1,0 +1,9 @@
+// Anything with "null" requires a translation. Contribute to translation via a PR!
+const TRANSLATIONS = {
+  chat: {
+    "send-message": null,
+    "reset-chat": null,
+  },
+};
+
+export default TRANSLATIONS;

--- a/src/locales/tr/common.js
+++ b/src/locales/tr/common.js
@@ -1,0 +1,9 @@
+// Anything with "null" requires a translation. Contribute to translation via a PR!
+const TRANSLATIONS = {
+  chat: {
+    "send-message": null,
+    "reset-chat": null,
+  },
+};
+
+export default TRANSLATIONS;

--- a/src/locales/verifyTranslations.mjs
+++ b/src/locales/verifyTranslations.mjs
@@ -1,0 +1,100 @@
+import { resources } from "./resources.js";
+const languageNames = new Intl.DisplayNames(Object.keys(resources), {
+  type: "language",
+});
+
+function langDisplayName(lang) {
+  return languageNames.of(lang);
+}
+
+function compareStructures(lang, a, b, subdir = null) {
+  //if a and b aren't the same type, they can't be equal
+  if (typeof a !== typeof b && a !== null && b !== null) {
+    console.log("Invalid type comparison", [
+      {
+        lang,
+        a: typeof a,
+        b: typeof b,
+        values: {
+          a,
+          b,
+        },
+        ...(!!subdir ? { subdir } : {}),
+      },
+    ]);
+    return false;
+  }
+
+  // Need the truthy guard because
+  // typeof null === 'object'
+  if (a && typeof a === "object") {
+    var keysA = Object.keys(a).sort(),
+      keysB = Object.keys(b).sort();
+
+    //if a and b are objects with different no of keys, unequal
+    if (keysA.length !== keysB.length) {
+      console.log("Keys are missing!", {
+        [lang]: keysA,
+        en: keysB,
+        ...(!!subdir ? { subdir } : {}),
+        diff: {
+          added: keysB.filter((key) => !keysA.includes(key)),
+          removed: keysA.filter((key) => !keysB.includes(key)),
+        },
+      });
+      return false;
+    }
+
+    //if keys aren't all the same, unequal
+    if (
+      !keysA.every(function (k, i) {
+        return k === keysB[i];
+      })
+    ) {
+      console.log("Keys are not equal!", {
+        [lang]: keysA,
+        en: keysB,
+        ...(!!subdir ? { subdir } : {}),
+      });
+      return false;
+    }
+
+    //recurse on the values for each key
+    return keysA.every(function (key) {
+      //if we made it here, they have identical keys
+      return compareStructures(lang, a[key], b[key], key);
+    });
+
+    //for primitives just ignore since we don't check values.
+  } else {
+    return true;
+  }
+}
+
+const failed = [];
+const TRANSLATIONS = {};
+for (const [lang, { common }] of Object.entries(resources))
+  TRANSLATIONS[lang] = common;
+const PRIMARY = { ...TRANSLATIONS["en"] };
+delete TRANSLATIONS["en"];
+
+console.log(
+  `The following translation files will be verified: [${Object.keys(
+    TRANSLATIONS
+  ).join(",")}]`
+);
+for (const [lang, translations] of Object.entries(TRANSLATIONS)) {
+  const passed = compareStructures(lang, translations, PRIMARY);
+  console.log(`${langDisplayName(lang)} (${lang}): ${passed ? "✅" : "❌"}`);
+  !passed && failed.push(lang);
+}
+
+if (failed.length !== 0)
+  throw new Error(
+    `The following translations files are INVALID and need fixing. Please see logs`,
+    failed
+  );
+console.log(
+  `👍 All translation files located match the schema defined by the English file!`
+);
+process.exit(0);

--- a/src/locales/vn/common.js
+++ b/src/locales/vn/common.js
@@ -1,0 +1,9 @@
+// Anything with "null" requires a translation. Contribute to translation via a PR!
+const TRANSLATIONS = {
+  chat: {
+    "send-message": null,
+    "reset-chat": null,
+  },
+};
+
+export default TRANSLATIONS;

--- a/src/locales/zh/common.js
+++ b/src/locales/zh/common.js
@@ -1,0 +1,9 @@
+// Anything with "null" requires a translation. Contribute to translation via a PR!
+const TRANSLATIONS = {
+  chat: {
+    "send-message": null,
+    "reset-chat": null,
+  },
+};
+
+export default TRANSLATIONS;

--- a/src/locales/zh_TW/common.js
+++ b/src/locales/zh_TW/common.js
@@ -1,0 +1,9 @@
+// Anything with "null" requires a translation. Contribute to translation via a PR!
+const TRANSLATIONS = {
+  chat: {
+    "send-message": null,
+    "reset-chat": null,
+  },
+};
+
+export default TRANSLATIONS;

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -3,20 +3,16 @@ import ReactDOM from "react-dom/client";
 import App from "./App.jsx";
 import "./index.css";
 import { parseStylesSrc } from "./utils/constants.js";
-const appElement = document.createElement("div");
+import { initI18n } from "./i18n.js";
 
+const appElement = document.createElement("div");
 document.body.appendChild(appElement);
-const root = ReactDOM.createRoot(appElement);
-root.render(
-  <React.StrictMode>
-    <App />
-  </React.StrictMode>
-);
 
 const scriptSettings = Object.assign(
   {},
   document?.currentScript?.dataset || {}
 );
+
 export const embedderSettings = {
   settings: scriptSettings,
   stylesSrc: parseStylesSrc(document?.currentScript?.src),
@@ -29,3 +25,13 @@ export const embedderSettings = {
     base: `allm-text-[#222628] allm-rounded-t-[18px] allm-rounded-br-[18px] allm-rounded-bl-[4px] allm-mr-[37px] allm-ml-[9px]`,
   },
 };
+
+// Initialize i18n after settings are available
+initI18n(scriptSettings);
+
+const root = ReactDOM.createRoot(appElement);
+root.render(
+  <React.StrictMode>
+    <App />
+  </React.StrictMode>
+);

--- a/yarn.lock
+++ b/yarn.lock
@@ -184,6 +184,13 @@
   dependencies:
     "@babel/helper-plugin-utils" "^7.22.5"
 
+"@babel/runtime@^7.23.2", "@babel/runtime@^7.23.9":
+  version "7.27.0"
+  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.27.0.tgz#fbee7cf97c709518ecc1f590984481d5460d4762"
+  integrity sha512-VtPOkrdPHZsKc/clNqyi9WUA8TINkZ4cGk63UUE3u4pmB2k+ZMQRDuIOagv8UVd6j7k0T3+RRIb7beKTebNbcw==
+  dependencies:
+    regenerator-runtime "^0.14.0"
+
 "@babel/template@^7.22.15", "@babel/template@^7.23.9":
   version "7.23.9"
   resolved "https://registry.yarnpkg.com/@babel/template/-/template-7.23.9.tgz#f881d0487cba2828d3259dcb9ef5005a9731011a"
@@ -1788,10 +1795,31 @@ highlight.js@^11.9.0:
   resolved "https://registry.yarnpkg.com/highlight.js/-/highlight.js-11.9.0.tgz#04ab9ee43b52a41a047432c8103e2158a1b8b5b0"
   integrity sha512-fJ7cW7fQGCYAkgv4CPfwFHrfd/cLS4Hau96JuJ+ZTOWhjnhoeN1ub1tFmALm/+lW5z4WCAuAV9bm05AP0mS6Gw==
 
+html-parse-stringify@^3.0.1:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/html-parse-stringify/-/html-parse-stringify-3.0.1.tgz#dfc1017347ce9f77c8141a507f233040c59c55d2"
+  integrity sha512-KknJ50kTInJ7qIScF3jeaFRpMpE8/lfiTdzf/twXyPBLAGrLRTmkz3AdTnKeh40X8k9L2fdYwEp/42WGXIRGcg==
+  dependencies:
+    void-elements "3.1.0"
+
 human-signals@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/human-signals/-/human-signals-2.1.0.tgz#dc91fcba42e4d06e4abaed33b3e7a3c02f514ea0"
   integrity sha512-B4FFZ6q/T2jhhksgkbEW3HBvWIfDW85snkQgawt07S7J5QXTk6BkNV+0yAeZrM5QpMAdYlocGoljn0sJ/WQkFw==
+
+i18next-browser-languagedetector@^7.2.1:
+  version "7.2.2"
+  resolved "https://registry.yarnpkg.com/i18next-browser-languagedetector/-/i18next-browser-languagedetector-7.2.2.tgz#748e7dc192847613911d8a79d9d9a6c2d266133e"
+  integrity sha512-6b7r75uIJDWCcCflmbof+sJ94k9UQO4X0YR62oUfqGI/GjCLVzlCwu8TFdRZIqVLzWbzNcmkmhfqKEr4TLz4HQ==
+  dependencies:
+    "@babel/runtime" "^7.23.2"
+
+i18next@^23.11.3:
+  version "23.16.8"
+  resolved "https://registry.yarnpkg.com/i18next/-/i18next-23.16.8.tgz#3ae1373d344c2393f465556f394aba5a9233b93a"
+  integrity sha512-06r/TitrM88Mg5FdUXAKL96dJMzgqLE5dv3ryBAra4KCwD9mJ4ndOTS95ZuymIGoE+2hzfdaMak2X11/es7ZWg==
+  dependencies:
+    "@babel/runtime" "^7.23.2"
 
 ignore-by-default@^1.0.1:
   version "1.0.1"
@@ -2694,6 +2722,14 @@ react-dom@^18.2.0:
     loose-envify "^1.1.0"
     scheduler "^0.23.0"
 
+react-i18next@^14.1.1:
+  version "14.1.3"
+  resolved "https://registry.yarnpkg.com/react-i18next/-/react-i18next-14.1.3.tgz#85525c4294ef870ddd3f5d184e793cae362f47cb"
+  integrity sha512-wZnpfunU6UIAiJ+bxwOiTmBOAaB14ha97MjOEnLGac2RJ+h/maIYXZuTHlmyqQVX1UVHmU1YDTQ5vxLmwfXTjw==
+  dependencies:
+    "@babel/runtime" "^7.23.9"
+    html-parse-stringify "^3.0.1"
+
 react-is@^16.13.1:
   version "16.13.1"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.13.1.tgz#789729a4dc36de2999dc156dd6c1d9c18cea56a4"
@@ -2736,6 +2772,11 @@ reflect.getprototypeof@^1.0.4:
     get-intrinsic "^1.2.1"
     globalthis "^1.0.3"
     which-builtin-type "^1.1.3"
+
+regenerator-runtime@^0.14.0:
+  version "0.14.1"
+  resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.14.1.tgz#356ade10263f685dda125100cd862c1db895327f"
+  integrity sha512-dYnhHh0nJoMfnkZs6GmmhFknAGRrLznOu5nc9ML+EJxGvrx6H7teuevqVqCuPcPK//3eDrrjQhehXVx9cnkGdw==
 
 regexp.prototype.flags@^1.5.0, regexp.prototype.flags@^1.5.1:
   version "1.5.1"
@@ -3326,6 +3367,11 @@ vite@^5.0.0:
     rollup "^4.2.0"
   optionalDependencies:
     fsevents "~2.3.3"
+
+void-elements@3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/void-elements/-/void-elements-3.1.0.tgz#614f7fbf8d801f0bb5f0661f5b2f5785750e4f09"
+  integrity sha512-Dhxzh5HZuiHQhbvTW9AMetFfBHDMYpo23Uo9btPXgdYP+3T5S+p+jgNy7spra+veYhBP2dCSgxR/i2Y02h5/6w==
 
 which-boxed-primitive@^1.0.2:
   version "1.0.2"


### PR DESCRIPTION
- Add support for i18n language translations
- Support for en, fr as starting languages
- Add `data-send-message-text` and `data-reset-chat-text` text overrides
- Update documentation for new attributes

resolves https://github.com/Mintplex-Labs/anything-llm/issues/3529