### PR TITLE
Convert chat widget to inline embed instead of modal popup

### DIFF
--- a/index.html
+++ b/index.html
@@ -7,16 +7,14 @@
 
   <body>
     <h1>This is an example testing page for embedded AnythingLLM.</h1>
-    <!--
-      Inline embed: place a container div with a set height/width, then put the script inside it.
-      The chat widget will fill the container like an iframe.
 
-      <div style="width: 400px; height: 700px;">
-        <script data-embed-id="example-uuid" data-base-api-url='http://localhost:3001/api/embed'
+    <div style="width: 400px; height: 700px;">
+      <script
+        data-embed-id="8b773266-1c3d-4067-9d91-0aa8b6549293"
+        data-base-api-url="https://p01--anythingllm--rq7jmmv9zl9d.code.run/api/embed"
         src="/dist/anythingllm-chat-widget.js">
-        </script>
-      </div>
-    -->
+      </script>
+    </div>
   </body>
 
 </html>

--- a/index.html
+++ b/index.html
@@ -12,6 +12,7 @@
       <script
         data-embed-id="8b773266-1c3d-4067-9d91-0aa8b6549293"
         data-base-api-url="https://p01--anythingllm--rq7jmmv9zl9d.code.run/api/embed"
+        data-no-sponsor="1"
         src="/dist/anythingllm-chat-widget.js">
       </script>
     </div>

--- a/index.html
+++ b/index.html
@@ -12,7 +12,7 @@
       <script
         data-embed-id="8b773266-1c3d-4067-9d91-0aa8b6549293"
         data-base-api-url="https://p01--anythingllm--rq7jmmv9zl9d.code.run/api/embed"
-        src="/dist/anythingllm-chat-widget.min.js">
+        src="/dist/anythingllm-chat-widget.js">
       </script>
     </div>
   </body>

--- a/index.html
+++ b/index.html
@@ -12,7 +12,7 @@
       <script
         data-embed-id="8b773266-1c3d-4067-9d91-0aa8b6549293"
         data-base-api-url="https://p01--anythingllm--rq7jmmv9zl9d.code.run/api/embed"
-        src="/dist/anythingllm-chat-widget.js">
+        src="/dist/anythingllm-chat-widget.min.js">
       </script>
     </div>
   </body>

--- a/index.html
+++ b/index.html
@@ -8,7 +8,7 @@
   <body>
     <h1>This is an example testing page for embedded AnythingLLM.</h1>
 
-    <div style="width: 400px; height: 700px;">
+    <div style="width: 400px; height: 700px; margin: 0 auto;">
       <script
         data-embed-id="8b773266-1c3d-4067-9d91-0aa8b6549293"
         data-base-api-url="https://p01--anythingllm--rq7jmmv9zl9d.code.run/api/embed"

--- a/index.html
+++ b/index.html
@@ -8,9 +8,14 @@
   <body>
     <h1>This is an example testing page for embedded AnythingLLM.</h1>
     <!--
-      <script data-embed-id="example-uuid" data-base-api-url='http://localhost:3001/api/embed' data-open-on-load="on"
-      src="/dist/anythingllm-chat-widget.js"> USE THIS SRC FOR DEVELOPMENT SO CHANGES APPEAR!
-      </script>
+      Inline embed: place a container div with a set height/width, then put the script inside it.
+      The chat widget will fill the container like an iframe.
+
+      <div style="width: 400px; height: 700px;">
+        <script data-embed-id="example-uuid" data-base-api-url='http://localhost:3001/api/embed'
+        src="/dist/anythingllm-chat-widget.js">
+        </script>
+      </div>
     -->
   </body>
 

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,74 +1,31 @@
 import useGetScriptAttributes from "@/hooks/useScriptAttributes";
 import useSessionId from "@/hooks/useSessionId";
-import useOpenChat from "@/hooks/useOpen";
 import Head from "@/components/Head";
-import OpenButton from "@/components/OpenButton";
 import ChatWindow from "./components/ChatWindow";
-import { useEffect } from "react";
 import { I18nextProvider } from "react-i18next";
 import i18next from "@/i18n";
 
 export default function App() {
-  const { isChatOpen, toggleOpenChat } = useOpenChat();
   const embedSettings = useGetScriptAttributes();
   const sessionId = useSessionId();
 
-  useEffect(() => {
-    if (embedSettings.openOnLoad === "on") {
-      toggleOpenChat(true);
-    }
-  }, [embedSettings.loaded]);
-
   if (!embedSettings.loaded) return null;
-
-  const positionClasses = {
-    "bottom-left": "allm-bottom-0 allm-left-0 allm-ml-4",
-    "bottom-right": "allm-bottom-0 allm-right-0 allm-mr-4",
-    "top-left": "allm-top-0 allm-left-0 allm-ml-4 allm-mt-4",
-    "top-right": "allm-top-0 allm-right-0 allm-mr-4 allm-mt-4",
-  };
-
-  const position = embedSettings.position || "bottom-right";
-  const windowWidth = embedSettings.windowWidth ?? "400px";
-  const windowHeight = embedSettings.windowHeight ?? "700px";
 
   return (
     <I18nextProvider i18n={i18next}>
       <Head />
       <div
         id="anything-llm-embed-chat-container"
-        className={`allm-fixed allm-inset-0 allm-z-50 ${isChatOpen ? "allm-block" : "allm-hidden"}`}
+        className="allm-w-full allm-h-full allm-bg-white allm-rounded-2xl allm-border allm-border-gray-300 allm-shadow-[0_4px_14px_rgba(0,0,0,0.25)] allm-flex allm-flex-col allm-overflow-hidden"
+        style={{
+          maxWidth: embedSettings.windowWidth ?? "100%",
+          maxHeight: embedSettings.windowHeight ?? "100%",
+          height: "100%",
+          width: "100%",
+        }}
       >
-        <div
-          style={{
-            maxWidth: windowWidth,
-            maxHeight: windowHeight,
-            height: "100%",
-          }}
-          className={`allm-h-full allm-w-full allm-bg-white allm-fixed allm-bottom-0 allm-right-0 allm-mb-4 allm-md:mr-4 allm-rounded-2xl allm-border allm-border-gray-300 allm-shadow-[0_4px_14px_rgba(0,0,0,0.25)] allm-flex allm-flex-col ${positionClasses[position]}`}
-          id="anything-llm-chat"
-        >
-          {isChatOpen && (
-            <ChatWindow
-              closeChat={() => toggleOpenChat(false)}
-              settings={embedSettings}
-              sessionId={sessionId}
-            />
-          )}
-        </div>
+        <ChatWindow settings={embedSettings} sessionId={sessionId} />
       </div>
-      {!isChatOpen && (
-        <div
-          id="anything-llm-embed-chat-button-container"
-          className={`allm-fixed allm-bottom-0 ${positionClasses[position]} allm-mb-4 allm-z-50`}
-        >
-          <OpenButton
-            settings={embedSettings}
-            isOpen={isChatOpen}
-            toggleOpen={() => toggleOpenChat(true)}
-          />
-        </div>
-      )}
     </I18nextProvider>
   );
 }

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -16,7 +16,7 @@ export default function App() {
       <Head />
       <div
         id="anything-llm-embed-chat-container"
-        className="allm-w-full allm-h-full allm-bg-white allm-rounded-2xl allm-border allm-border-gray-300 allm-shadow-[0_4px_14px_rgba(0,0,0,0.25)] allm-flex allm-flex-col allm-overflow-hidden"
+        className="allm-w-full allm-h-full allm-bg-white allm-flex allm-flex-col allm-overflow-hidden"
         style={{
           maxWidth: embedSettings.windowWidth ?? "100%",
           maxHeight: embedSettings.windowHeight ?? "100%",

--- a/src/components/ChatWindow/Header/index.jsx
+++ b/src/components/ChatWindow/Header/index.jsx
@@ -6,7 +6,6 @@ import {
   Copy,
   DotsThreeOutlineVertical,
   Envelope,
-  X,
 } from "@phosphor-icons/react";
 import { useEffect, useRef, useState } from "react";
 
@@ -14,7 +13,6 @@ export default function ChatWindowHeader({
   sessionId,
   settings = {},
   iconUrl = null,
-  closeChat,
   setChatHistory,
 }) {
   const [showingOptions, setShowOptions] = useState(false);
@@ -68,14 +66,6 @@ export default function ChatWindowHeader({
             <DotsThreeOutlineVertical size={20} weight="fill" />
           </button>
         )}
-        <button
-          type="button"
-          onClick={closeChat}
-          className="allm-bg-transparent hover:allm-cursor-pointer allm-border-none hover:allm-bg-gray-100 allm-rounded-sm allm-text-slate-800/60"
-          aria-label="Close"
-        >
-          <X size={20} weight="bold" />
-        </button>
       </div>
       <OptionsMenu
         settings={settings}

--- a/src/components/ChatWindow/index.jsx
+++ b/src/components/ChatWindow/index.jsx
@@ -6,7 +6,7 @@ import Sponsor from "../Sponsor";
 import { ChatHistoryLoading } from "./ChatContainer/ChatHistory";
 import ResetChat from "../ResetChat";
 
-export default function ChatWindow({ closeChat, settings, sessionId }) {
+export default function ChatWindow({ settings, sessionId }) {
   const { chatHistory, setChatHistory, loading } = useChatHistory(
     settings,
     sessionId
@@ -19,7 +19,6 @@ export default function ChatWindow({ closeChat, settings, sessionId }) {
           sessionId={sessionId}
           settings={settings}
           iconUrl={settings.brandImageUrl}
-          closeChat={closeChat}
           setChatHistory={setChatHistory}
         />
         <ChatHistoryLoading />
@@ -40,7 +39,6 @@ export default function ChatWindow({ closeChat, settings, sessionId }) {
           sessionId={sessionId}
           settings={settings}
           iconUrl={settings.brandImageUrl}
-          closeChat={closeChat}
           setChatHistory={setChatHistory}
         />
       )}
@@ -57,7 +55,6 @@ export default function ChatWindow({ closeChat, settings, sessionId }) {
           setChatHistory={setChatHistory}
           settings={settings}
           sessionId={sessionId}
-          closeChat={closeChat}
         />
       </div>
     </div>

--- a/src/components/ResetChat/index.jsx
+++ b/src/components/ResetChat/index.jsx
@@ -5,7 +5,6 @@ export default function ResetChat({
   setChatHistory,
   settings,
   sessionId,
-  closeChat,
 }) {
   const { t } = useTranslation();
 
@@ -23,21 +22,6 @@ export default function ResetChat({
       >
         {settings.resetChatText || t("chat.reset-chat")}
       </button>
-      {settings.noHeader && (
-        <>
-          <p className="allm-m-0 allm-h-fit allm-text-sm allm-text-[#7A7D7E]">
-            |
-          </p>
-          <button
-            type="button"
-            style={{ color: "#7A7D7E" }}
-            className="allm-h-fit allm-px-0 hover:allm-cursor-pointer allm-border-none allm-text-sm allm-bg-transparent hover:allm-opacity-80 hover:allm-underline"
-            onClick={closeChat}
-          >
-            Close Chat
-          </button>
-        </>
-      )}
     </div>
   );
 }

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -5,17 +5,19 @@ import "./index.css";
 import { parseStylesSrc } from "./utils/constants.js";
 import { initI18n } from "./i18n.js";
 
-const appElement = document.createElement("div");
-document.body.appendChild(appElement);
+// Mount into the script tag's parent element so the chat renders inline,
+// like an iframe embedded in the page.
+const currentScript = document.currentScript;
+const appElement = currentScript?.parentElement || document.body;
 
 const scriptSettings = Object.assign(
   {},
-  document?.currentScript?.dataset || {}
+  currentScript?.dataset || {}
 );
 
 export const embedderSettings = {
   settings: scriptSettings,
-  stylesSrc: parseStylesSrc(document?.currentScript?.src),
+  stylesSrc: parseStylesSrc(currentScript?.src),
   USER_STYLES: {
     msgBg: scriptSettings?.userBgColor ?? "#3DBEF5",
     base: `allm-text-white allm-rounded-t-[18px] allm-rounded-bl-[18px] allm-rounded-br-[4px] allm-mx-[20px]`,


### PR DESCRIPTION
## Summary
This PR refactors the AnythingLLM chat widget from a modal popup interface to an inline embedded component that renders directly within a container element on the host page.

## Key Changes

- **Removed modal/popup functionality**: Eliminated `useOpenChat` hook and all open/close state management for the chat window
- **Removed toggle button**: Deleted `OpenButton` component and related UI for opening/closing the chat
- **Simplified App.jsx**: Removed position-based styling, open-on-load logic, and conditional rendering of chat elements
- **Inline rendering**: Chat now renders directly in the parent container with full width/height instead of a fixed positioned modal
- **Updated mount point**: Changed `main.jsx` to mount the app into the script tag's parent element (`currentScript.parentElement`) rather than creating a new div, allowing the chat to render inline like an embedded iframe
- **Removed close button**: Eliminated the X close button from the chat header and "Close Chat" option from the reset menu
- **Simplified ChatWindow**: Removed `closeChat` prop and related callback logic throughout the component tree

## Implementation Details

The widget now expects to be embedded in a container div with explicit dimensions:
```html
<div style="width: 400px; height: 700px;">
  <script data-embed-id="..." src="..."></script>
</div>
```

The chat renders at 100% of the container's dimensions, making it suitable for embedding in sidebars, dedicated chat sections, or other inline layouts rather than as a floating modal overlay.

https://claude.ai/code/session_01NSKGTGmcWCFuprjGE8z6Zx