### PR TITLE
fix: prevent chat input textarea height jump and top-aligned placeholder

### DIFF
--- a/src/components/ChatWindow/ChatContainer/PromptInput/index.jsx
+++ b/src/components/ChatWindow/ChatContainer/PromptInput/index.jsx
@@ -62,6 +62,7 @@ export default function PromptInput({
             >
               <textarea
                 ref={textareaRef}
+                rows={1}
                 onKeyUp={adjustTextArea}
                 onKeyDown={captureEnter}
                 onChange={onChange}
@@ -73,7 +74,7 @@ export default function PromptInput({
                   adjustTextArea(e);
                 }}
                 value={message}
-                className="allm-font-sans allm-border-none allm-cursor-text allm-max-h-[100px] allm-text-[14px] allm-mx-2 allm-py-2 allm-w-full allm-text-black allm-bg-transparent placeholder:allm-text-slate-800/60 allm-resize-none active:allm-outline-none focus:allm-outline-none allm-flex-grow"
+                className="allm-box-border allm-font-sans allm-border-none allm-cursor-text allm-max-h-[100px] allm-text-[14px] allm-leading-5 allm-mx-2 allm-py-2 allm-w-full allm-text-black allm-bg-transparent placeholder:allm-text-slate-800/60 allm-resize-none active:allm-outline-none focus:allm-outline-none allm-flex-grow"
                 placeholder={settings.sendMessageText || t("chat.send-message")}
                 id="message-input"
               />


### PR DESCRIPTION
## Summary

Fixes two related layout bugs on the embed widget's prompt input:

- **Empty input was rendered as 2 rows** (browser default for `<textarea>` with no `rows` attribute), with the `Send a message` placeholder pinned to the first line and an empty second line below it.
- **First keystroke caused the textarea to jump ~16px taller** and the caret/text shifted upward inside the box.

## Reproduction (before fix)

1. Embed the widget on a page and open the chat panel.
2. Focus the input — placeholder appears at the top of an oversized box.
3. Type any single character — the input grows abruptly by ~2× vertical padding, and the text sits at the top of the now-larger box.

## Root cause

`tailwind.config.js` sets `corePlugins.preflight: false`, so Tailwind's global `* { box-sizing: border-box; }` reset is skipped and the textarea defaults to `content-box`.

The autoresize logic in `src/components/ChatWindow/ChatContainer/PromptInput/index.jsx`:

```js
element.style.height = "auto";
element.style.height = event.target.value.length !== 0
  ? element.scrollHeight + "px"
  : "auto";
```

`scrollHeight` includes vertical padding, but a content-box `height` is interpreted as the content area only — so vertical padding ends up counted twice. The rendered box overshoots by ~2× `py` on the first keystroke.

The same component renders fine in the main app (`frontend/`) because that build keeps preflight enabled, applying `box-sizing: border-box` globally.

## Changes

- `rows={1}` on the textarea so the empty state is one line tall and the placeholder centers naturally next to the send button.
- `allm-box-border` so `scrollHeight`-based autoresize matches the rendered box height regardless of the global preflight setting.
- `allm-leading-5` to lock line-height; `allm-text-[14px]` only sets font-size in JIT, leaving line-height to inheritance from the host page.

## Test plan

- [ ] Build the widget and embed it on a fresh page.
- [ ] Confirm placeholder is vertically centered (no longer pinned to the top).
- [ ] Type a single character — textarea height stays the same.
- [ ] Type until the input wraps — grows by exactly one line-height per wrapped row, capped at `max-h-[100px]`.
- [ ] Clear all text — returns to one-line height.
- [ ] Cross-browser smoke: Chrome / Firefox / Safari.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
